### PR TITLE
Add go github action for pipelines instead of travis

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,30 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+
+    - name: Tests
+      run: go test -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-go:
- - 1.12
-notifications:
-  email:
-      - ionathan@gmail.com
-      - marcosnils@gmail.com


### PR DESCRIPTION
Travis was acquired and pipelines are starting to fade away. Github actions is a good alternative to it